### PR TITLE
fix: inverted two finger scrolling

### DIFF
--- a/src/views/Schema.vue
+++ b/src/views/Schema.vue
@@ -101,8 +101,8 @@
       movX = e.movementX
       movY = e.movementY
     }
-    state.schemaView.translate.x += movX
-    state.schemaView.translate.y += movY
+    state.schemaView.translate.x -= movX
+    state.schemaView.translate.y -= movY
   }
   const dragEnd = (e: MouseEvent) => {
     isDragging.value = false


### PR DESCRIPTION
Fixes issue #15: Two finger scrolling is inverted (by @ImBIOS)

Subtracting touchpad gesture delta from the translation in the transform matrix.
Works like a charm for me. But that's basically all I can say about this.